### PR TITLE
Fix security issue with update being performed before attribute change.

### DIFF
--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -93,9 +93,6 @@ module ApiMe
   end
 
   def new
-    @object = model_klass.new
-    authorize_resource @object
-
     render_errors(['new endpoint not supported'], 404)
   end
 
@@ -108,9 +105,6 @@ module ApiMe
   end
 
   def edit
-    @object = find_resource
-    
-
     render_errors(['edit endpoint not supported'], 404)
   end
 

--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -237,7 +237,7 @@ module ApiMe
   end
 
   def update_resource!
-    @object.save!(object_params) 
+    @object.save!(object_params)
   end
 
   def destroy_resource!

--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -109,13 +109,14 @@ module ApiMe
 
   def edit
     @object = find_resource
-    authorize_resource @object
+    
 
     render_errors(['edit endpoint not supported'], 404)
   end
 
   def update
     @object = find_resource
+    @object.assign_attributes(object_params)
     authorize_resource @object
     update_resource!
 
@@ -242,7 +243,7 @@ module ApiMe
   end
 
   def update_resource!
-    @object.update!(object_params)
+    @object.update!(object_params) 
   end
 
   def destroy_resource!

--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -237,7 +237,7 @@ module ApiMe
   end
 
   def update_resource!
-    @object.update!(object_params) 
+    @object.save!(object_params) 
   end
 
   def destroy_resource!


### PR DESCRIPTION
Authorization needs to be done after attributes are set on the object, but before it is saved so that authorization makes sure the object being saved is the one with the attributes being validation against, since we catch validation errors via exception on DB commit.

This fixes an issue where an API request could come in to do request something crazy like switch the organization or something and it wouldn't fail because the user being authorized would be in the correct organization as the object before its attributes were changed.