### PR TITLE
Remove params from create_resource! and update_resource!

### DIFF
--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -235,11 +235,11 @@ module ApiMe
   end
 
   def create_resource!
-    @object.save!(object_params)
+    @object.save!
   end
 
   def update_resource!
-    @object.save!(object_params)
+    @object.save!
   end
 
   def destroy_resource!


### PR DESCRIPTION
The `save!` calls in `create_resource!` and `update_resource!` implied that these params were not already set on the model, when this is done previously in the `create`/`update` methods.
